### PR TITLE
Rename venue to location in schedule

### DIFF
--- a/themes/eventre-hugo/layouts/_default/schedule.html
+++ b/themes/eventre-hugo/layouts/_default/schedule.html
@@ -36,7 +36,7 @@
                   <div class="time">Time</div>
                   <div class="speaker">Speaker</div>
                   <div class="subject">Subject</div>
-                  <div class="venue">Venue</div>
+                  <div class="venue">Location</div>
                 </li>
                 <!-- Schedule Details -->
                 {{ range .tablist_items }}

--- a/themes/eventre-hugo/layouts/index.html
+++ b/themes/eventre-hugo/layouts/index.html
@@ -222,7 +222,7 @@
                   <div class="time">Time</div>
                   <div class="speaker">Speaker</div>
                   <div class="subject">Subject</div>
-                  <div class="venue">Venue</div>
+                  <div class="venue">Location</div>
                 </li>
                 <!-- Schedule Details -->
                 {{ range .tablist_items }}


### PR DESCRIPTION
A few folks have mentioned to me that the use of venue on the schedule was confusing to them.  Generally venue refers to an overall building, not a room within a building.  Some of the room names contributed to this confusion, such as Stadium.  Location is a bit of a broader term that is more applicable to room names.